### PR TITLE
make address lowercase

### DIFF
--- a/idex/client.py
+++ b/idex/client.py
@@ -168,6 +168,7 @@ class Client(object):
         nonce_res = self.get_my_next_nonce()
         self._start_nonce = nonce_res['nonce']
         if private_key:
+            assert len(private_key) == 66, "Invalid private key. Forgot 0x in front?"
             self._private_key = private_key
 
     def get_wallet_address(self):

--- a/idex/client.py
+++ b/idex/client.py
@@ -164,7 +164,7 @@ class Client(object):
         :returns: nothing
 
         """
-        self._wallet_address = address
+        self._wallet_address = address.lower()
         nonce_res = self.get_my_next_nonce()
         self._start_nonce = nonce_res['nonce']
         if private_key:


### PR DESCRIPTION
Idex does not accept mixed/uppercase addresses for querying orders. For some reason they do accept mixed/uppercase for querying balances, but lowercase should always work.